### PR TITLE
Make EXDATES iterable (#1)

### DIFF
--- a/src/ical_event_handler.py
+++ b/src/ical_event_handler.py
@@ -31,6 +31,17 @@ def get_non_recurrences_from_event(event, start_date, end_date):
     dtstart = event.get('DTSTART').dt.astimezone(TZ)
     return [dtstart] if 'DTSTART' in event and start_date <= dtstart < end_date else []
 
+def is_occurrence_excluded(occurrence, exdates):
+    exdate_list = exdates if isinstance(exdates, list) else [exdates]
+
+    for exdate in exdate_list:
+        exdate_str = exdate.to_ical().decode('utf-8')
+        exdate_datetime = datetime.strptime(exdate_str, '%Y%m%dT%H%M%S')
+        if occurrence.date() == exdate_datetime.date():
+            return True
+
+    return False
+
 def get_todays_events(calendar):
     today = datetime.now().astimezone(TZ)
     tommorow = today + timedelta(days=1)
@@ -42,7 +53,7 @@ def get_todays_events(calendar):
             non_recurrences = get_non_recurrences_from_event(component, today, tommorow)
 
             for occurrence in recurrences + non_recurrences:
-                if 'EXDATE' in component and occurrence.date() in component['EXDATE']:
+                if 'EXDATE' in component and is_occurrence_excluded(occurrence, component['EXDATE']):
                     continue
                 
                 event = Event()


### PR DESCRIPTION
Closes #1 

## Findings
The bug is  located on the `occurrence.date() in component['EXDATE']`.
```python
# get_todays_events

for occurrence in recurrences + non_recurrences:
    if 'EXDATE' in component and occurrence.date() in component['EXDATE']:
        continue
```

There are two problems:
1. `component['EXDATE']` is not a list, when an iCal event has only one `EXDATE` field.
2. `component['EXDATE']` elements are not formatted dates. So the conditions were always false.

## Solution

```python
# get_todays_events

for occurrence in recurrences + non_recurrences:
    if 'EXDATE' in component and is_occurrence_excluded(occurrence, component['EXDATE']):
        continue
```

```python
def is_occurrence_excluded(occurrence, exdates):
    exdate_list = exdates if isinstance(exdates, list) else [exdates]

    for exdate in exdate_list:
        exdate_str = exdate.to_ical().decode('utf-8')
        exdate_datetime = datetime.strptime(exdate_str, '%Y%m%dT%H%M%S')
        if occurrence.date() == exdate_datetime.date():
            return True

    return False
```